### PR TITLE
fix bug in multi-band changes

### DIFF
--- a/geomockimages/imagecreator.py
+++ b/geomockimages/imagecreator.py
@@ -239,11 +239,11 @@ class GeoMockImage:
             bands.append(data_ar)
             band_idx += 1
 
-            if change_pixels > 0:
-                bands = self.add_change_pixels(
-                    bands=bands,
-                    change_pixels=change_pixels,
-                )
+        if change_pixels > 0:
+            bands = self.add_change_pixels(
+                bands=bands,
+                change_pixels=change_pixels,
+            )
 
         return bands
 


### PR DESCRIPTION
When trying to create a multi-band image pair with changing pixels, I got the following error:

```
Traceback (most recent call last):
  File "<string>", line 15, in <module>
  File "/opt/conda/envs/tradeaware-trainer/lib/python3.10/site-packages/geomockimages/imagecreator.py", line 129, in create
    band_list = self.add_img_pattern(
  File "/opt/conda/envs/tradeaware-trainer/lib/python3.10/site-packages/geomockimages/imagecreator.py", line 243, in add_img_pattern
    bands = self.add_change_pixels(
  File "/opt/conda/envs/tradeaware-trainer/lib/python3.10/site-packages/geomockimages/imagecreator.py", line 268, in add_change_pixels
    bands = self.apply_change(bands, change_spot_indices)
  File "/opt/conda/envs/tradeaware-trainer/lib/python3.10/site-packages/geomockimages/imagecreator.py", line 372, in apply_change
    bands[i][spot_indices] = bands[i][spot_indices] * change_factor
IndexError: list index out of range
```

It seems to be caused by a wrong indentation of the content of the if statement addressed here. This PR changes the wrong indentation to fix the error.